### PR TITLE
Refactor `init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b (for configuration)
 
 `./init app`
 
-`./init clean` to stop the application
+`./init clean` to remove `cfg.yaml`, `library.db` and binaries
 
 ### With `docker`
 

--- a/init
+++ b/init
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 api() {
-	cd ./cmd/api
+	cd "$PWD/cmd/api" || exit
 	go build && ./api
 }
 
@@ -12,7 +12,7 @@ dapi() {
 }
 
 ui() {
-	cd ./cmd/ui
+	cd "$PWD/cmd/ui" || exit
 	go build && ./ui
 }
 
@@ -22,11 +22,11 @@ app() {
 }
 
 clean() {
-	killall api ui
-	rm ./cmd/api/api ./cmd/api/cfg.yaml ./cmd/api/library.db
-	rm ./cmd/ui/ui
+	rm -i "$PWD/cmd/api/api" \
+		"$PWD/cmd/api/cfg.yaml" \
+		"$PWD/cmd/api/library.db" \
+		"$PWD/cmd/ui/ui"
 }
-
 
 dcompose() {
 	docker-compose up --build
@@ -36,4 +36,13 @@ dclean() {
 	docker stop restful-api && docker rm restful-api
 }
 
-$*
+cmds="api app clean dapi dclean dcompose ui"
+if [[ -n "$COMP_LINE" ]]; then
+	cl="${COMP_LINE##* }"
+	for c in ${cmds}; do
+		test -z "${cl}" -o "${c}" != "${c#${cl}}" && echo "$c"
+	done
+	exit
+fi
+
+"$@"


### PR DESCRIPTION
Refactored all uses of `cd` to `cd ... || exit`. Refactored
`$*` to `"$@"`. Refactored all relative paths to absolute paths. Added
tab-completion using BASH's programmable completion. Added `-i` option to
`rm` calls to prompt user before every removal. Updated `README.md`.
Resolves https://github.com/oglinuk/restful-go/issues/1.
