### PR TITLE
Refactor handler logic out of `main.go`

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,8 +1,6 @@
 package main
 
-import (
-	"github.com/oglinuk/restful-go/internal/api"
-)
+import "github.com/oglinuk/restful-go/internal/api"
 
 func main() {
 	api.Run()

--- a/cmd/ui/Dockerfile
+++ b/cmd/ui/Dockerfile
@@ -1,7 +1,13 @@
-FROM golang:1.17
+FROM golang:1.17 as build
 WORKDIR /go/src/github.com/oglinuk/restful-go/ui
 COPY . .
 RUN go mod download && go mod verify
+ENV CGO_ENABLED=0
 RUN go build -ldflags="-w -s"
+
+FROM scratch
+COPY --from=build /go/src/github.com/oglinuk/restful-go/ui/static /static
+COPY --from=build /go/src/github.com/oglinuk/restful-go/ui/templates /templates
+COPY --from=build /go/src/github.com/oglinuk/restful-go/ui/ui ui
 EXPOSE 9042
-ENTRYPOINT ["./ui"]
+ENTRYPOINT ["/ui"]

--- a/cmd/ui/main.go
+++ b/cmd/ui/main.go
@@ -1,78 +1,51 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"text/template"
 
 	"github.com/go-chi/chi/v5"
 )
 
+var (
+	tplDir = "templates/*"
+	tpl *template.Template
+)
+
 func main() {
-	tpl := template.Must(template.ParseGlob("templates/*"))
+	tpl = template.Must(template.ParseGlob(tplDir))
+	if tpl == nil {
+		log.Fatalf("template.Must(template.ParseGlob(\"%s\")", tplDir)
+	}
+
+	HOST := os.Getenv("HOST")
+	if HOST == "" {
+		HOST = "0.0.0.0"
+	}
+
+	PORT := os.Getenv("PORT")
+	if PORT == "" {
+		PORT = "9042"
+	}
+
+	addr := fmt.Sprintf("%s:%s", HOST, PORT)
 
 	r := chi.NewRouter()
 
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		br, err := getBooks()
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-		} else {
-			err = tpl.ExecuteTemplate(w, "index.html", br)
-			if err != nil {
-				http.Error(w, err.Error(), 500)
-			}
-		}
-	})
-
-	r.Post("/", func(w http.ResponseWriter, r *http.Request) {
-		// This is dumb, but required since PUT is not allowed in HTML forms
-		isUpdate := r.PostFormValue("_method")
-
-		if isUpdate != "" {
-			b, err := updateBookById(r)
-			if err != nil {
-				http.Error(w, err.Error(), 500)
-			} else {
-				http.Redirect(w, r, "/"+b.ID, http.StatusMovedPermanently)
-			}
-			return
-		}
-
-		id, err := createBook(r)
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-		} else {
-			http.Redirect(w, r, "/"+id, http.StatusMovedPermanently)
-		}
-	})
-
-	r.Get("/{id}", func(w http.ResponseWriter, r *http.Request) {
-		br, err := getBookById(chi.URLParam(r, "id"))
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-		} else {
-			err = tpl.ExecuteTemplate(w, "book.html", br)
-			if err != nil {
-				http.Error(w, err.Error(), 500)
-			}
-		}
-	})
-
-	r.Get("/create", func(w http.ResponseWriter, r *http.Request) {
-		err := tpl.ExecuteTemplate(w, "create.html", nil)
-		if err != nil {
-			http.Error(w, err.Error(), 500)
-		}
-	})
-
+	r.Post("/", createBook)
+	r.Get("/", getBooks)
+	r.Get("/{id}", getBookById)
+	r.Get("/ping", getHeartbeat)
+	r.Get("/create", createBook)
 	r.Get("/static/*", func(w http.ResponseWriter, r *http.Request) {
 		root := http.Dir("static")
 		fsrvr := http.StripPrefix("/static/", http.FileServer(root))
 		fsrvr.ServeHTTP(w, r)
 	})
 
-	addr := "0.0.0.0:9042"
 	log.Printf("Serving at %s ...\n", addr)
 	log.Fatal(http.ListenAndServe(addr, r))
 }

--- a/docs/code-reviews/1642914462/README.md
+++ b/docs/code-reviews/1642914462/README.md
@@ -52,10 +52,10 @@ For more information:
 
 **TODO**
 
-* [ ] Implement tab-completion
-* [ ] Refactor all relative paths be absolute paths
-* [ ] Refactor `$*` to `"$@"`
-* [ ] Refactor `cd` to `cd || exit`
+* [X] Implement tab-completion
+* [X] Refactor all relative paths be absolute paths
+* [X] Refactor `$*` to `"$@"`
+* [X] Refactor `cd` to `cd || exit`
 
 ## cmd/api/main.go
 
@@ -63,7 +63,7 @@ Since there is only one import, change from using `()` to a single line.
 
 **TODO**
 
-* [ ] Refactor `import` to one line
+* [X] Refactor `import` to one line
 
 ## cmd/ui/Dockerfile
 
@@ -73,17 +73,20 @@ multi-stage build and using a `scratch` image. The current image size is
 
 **TODO**
 
-* [ ] Refactor to using multi-stage build with `scratch` image
+* [X] Refactor to using multi-stage build with `scratch` image
 
 ## cmd/ui/main.go
 
 The `addr` variable is hardcoded. The implementation of route handlers is
-split between `main.go` and `handlers.go`.
+split between `main.go` and `handlers.go`. No check to ensure `tpl`
+variable is not `nil`. Missing route for `getHeartbeat` handler.
 
 **TODO**
 
-* [ ] Refactor `addr` to get `HOST` and `PORT` env variables
-* [ ] Refactor route handler logic entirely to `handlers.go`
+* [X] Add check to see if `tpl` is `nil`
+* [X] Refactor `addr` to get `HOST` and `PORT` env variables
+* [X] Refactor route handler logic entirely to `handlers.go`
+* [X] Add `getHeartbeat` to the router
 
 ## cmd/ui/models.go
 


### PR DESCRIPTION
Refactored `cmd/api/main.go` import statement to one line. Refactored
`cmd/ui/Dockerfile` to a multi-stage build and using the `scratch` image.
All handler logic has been refactored out of `main.go` and into
`handlers.go`.
